### PR TITLE
Simplify OFREP OpenAPI Definition

### DIFF
--- a/service/openapi.yaml
+++ b/service/openapi.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.0
+openapi: 3.1.0
 info:
   version: 0.1.0
   title: OpenFeature Remote Evaluation Protocol (OFREP)
@@ -11,9 +11,11 @@ security:
   - ApiKeyAuth: []
   - BearerAuth: []
 paths:
-  /ofrep/v1/evaluate/{key}:
+  /ofrep/v1/flags/{key}:
     post:
-      description: OFREP flag evaluation request
+      description: Evaluate an individual flag
+      tags:
+        - evaluate
       parameters:
         - name: key
           in: path
@@ -59,9 +61,11 @@ paths:
                 example: '2024-02-07T12:00:00Z'
         '500':
           description: Internal server error
-  /ofrep/v1/evaluate:
+  /ofrep/v1/flags:
     post:
-      description: OFREP bulk evaluation request
+      description: Bulk evaluate multiple flags
+      tags:
+        - evaluate
       requestBody:
         content:
           application/json:
@@ -95,103 +99,58 @@ paths:
                 example: '2024-02-07T12:00:00Z'
         '500':
           description: Internal server error
-  /ofrep/v1/flag/changes:
-    post:
-      description: OFREP polling endpoint to check if the flags have been modified
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/flags'
-      responses:
-        '200':
-          description: OFREP successful flag changes response
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/flagChange'
-        '400':
-          description: OFREP error response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/flagChangeFailure'
-        '401':
-          description: Unauthorized - You need credentials to access the API
-        '403':
-          description: Forbidden - You are not authorized to access the API
-        '429':
-          description: Rate limit reached on the Flag Management System
-          headers:
-            Retry-Later:
-              description: Indicates when to retry the request
-              schema:
-                type: string
-                format: date-time
-                example: '2024-02-07T12:00:00Z'
-        '500':
-          description: Internal server error
 components:
   securitySchemes:
     BearerAuth:
-      description: (optional) Bearer Authorization to your flag management system.
+      description: (optional) Bearer Authorization to your flag management system
       type: http
       scheme: bearer
     ApiKeyAuth:
-      description: (optional) API Key to your flag management system.
+      description: (optional) API Key to your flag management system
       type: apiKey
       in: header
       name: X-API-Key
   schemas:
     bulkEvaluationRequest:
-      description: Evaluate multiple flags in one request
+      description: Bulk evaluate multiple flags
       properties:
-        flags:
-          $ref: '#/components/schemas/flags'
         context:
           $ref: '#/components/schemas/context'
     bulkEvaluationSuccess:
       description: Response of the bulk evaluation
-      type: array
-      items:
-        properties:
-          key:
-            $ref: '#/components/schemas/key'
-          value:
-            type: object
-            description: Flag evaluation result
-          reason:
-            type: string
-            description: Reason matching OpenFeature reason
-          variant:
-            type: string
-            description: Variant of the evaluated flag value
-          metadata:
-            type: object
-            description: Arbitrary metadata supporting flag evaluation
-          errorCode:
-            type: string
-            description: OpenFeature compatible error code. See https://openfeature.dev/specification/types#error-code
-          errorDetails:
-            type: string
-            description: Optional error details description for logging or other needs
-          ETag:
-            $ref: '#/components/schemas/flagChange/properties/ETag'
-    bulkEvaluationFailure:
-      description: Bulk evaluation failure response
       properties:
-        errorCode:
-          type: string
-          description: Error code specific to the bulk evaluation.
-        errorDetails:
-          type: string
-          description: Optional error details description for logging or other needs
-      required:
-        - errorCode
-    flagChangeFailure:
-      description: Bulk evaluation failure response
+        flags:
+          type: array
+          items:
+            properties:
+              key:
+                $ref: '#/components/schemas/key'
+              value:
+                type: object
+                description: Flag evaluation result
+              reason:
+                type: string
+                description: Reason matching OpenFeature reason
+                externalDocs:
+                  url: https://openfeature.dev/specification/types#resolution-details
+              variant:
+                type: string
+                description: Variant of the evaluated flag value
+              metadata:
+                type: object
+                description: Arbitrary metadata supporting flag evaluation
+              errorCode:
+                type: string
+                description: OpenFeature compatible error code.
+                externalDocs:
+                  url: https://openfeature.dev/specification/types#error-code
+              errorDetails:
+                type: string
+                description: Optional error details description for logging or other needs
+            required:
+              - key
+    bulkEvaluationFailure:
+      description: Bulk evaluation failure response.
       properties:
         errorCode:
           type: string
@@ -204,8 +163,6 @@ components:
     evaluationRequest:
       description: Flag evaluation request
       properties:
-        flagType:
-          $ref: '#/components/schemas/flagType'
         context:
           $ref: '#/components/schemas/context'
     success:
@@ -235,8 +192,16 @@ components:
           $ref: '#/components/schemas/key'
         errorCode:
           type: string
-          enum: [FLAG_NOT_FOUND,PARSE_ERROR,TYPE_MISMATCH,TARGETING_KEY_MISSING,INVALID_CONTEXT,GENERAL]
-          description: OpenFeature compatible error code. See https://openfeature.dev/specification/types#error-code
+          enum:
+           - FLAG_NOT_FOUND
+           - PARSE_ERROR
+           - TYPE_MISMATCH
+           - TARGETING_KEY_MISSING
+           - INVALID_CONTEXT
+           - GENERAL
+          description: OpenFeature compatible error code.
+          externalDocs:
+            url: https://openfeature.dev/specification/types#error-code
         errorDetails:
           type: string
           description: Optional error details description for logging or other needs
@@ -247,39 +212,6 @@ components:
       type: string
       description: Feature flag key
       example: my-flag
-    flagType:
-      type: string
-      enum:
-        - string
-        - boolean
-        - integer
-        - float
-        - object
-      description: Type to evaluate the given flag
-    flags:
-      type: array
-      description: (optional) List of flags to be evaluated, if not set all the flag available will be evaluated against the context.
-      items:
-        $ref: '#/components/schemas/key'
-      example:
-        - my-flag
-        - my-other-flag
     context:
       type: object
       description: Context information for flag evaluation
-    flagChange:
-      description: Flag changes response.
-      properties:
-        key:
-          $ref: '#/components/schemas/key'
-        ETag:
-          type: string
-          description: identifier for a specific version of a resource. If the flag is modified the ETag should be different. It lets caches be more efficient and save bandwidth,the provider will refresh only the changed flags.
-          example: S1xXXGYIXzwhdCwKwMYUFRalIlJoJXLqbd0uYcm3sWg=
-        errorCode:
-          type: string
-          enum: [FLAG_NOT_FOUND,PARSE_ERROR,GENERAL]
-          description: OpenFeature compatible error code. See https://openfeature.dev/specification/types#error-code
-        errorDetails:
-          type: string
-          description: Optional error details description for logging or other needs


### PR DESCRIPTION
## This PR

- Updated the URI from evaluate to flags. Semi-related to https://github.com/open-feature/protocol/pull/2#discussion_r1496331648
- Removed the list of flags from the bulk eval API. Relates to https://github.com/open-feature/protocol/pull/2#discussion_r1493008250
- Removed request type from the request. Relates to https://github.com/open-feature/protocol/pull/2#discussion_r1472797815
- Removed ETag support. Relates to https://github.com/open-feature/protocol/pull/2#discussion_r1493008250
- Remove change API due to redundant behavior. Relates to https://github.com/open-feature/protocol/pull/2#discussion_r1496323381
- Updated the bulk API response to be an object. This will allow us to extend the response in a nonbreaking way in the future.

### Notes

This is a simplified version of the current proposal. I believe, in this case, less is more. It tends to be much easier to add new functionality than to change something. In my opinion, we should defer ETag and caching behavior until after we have the basics in place. I believe this proposal will work well when using both static and dynamic paradigms.