### PR TITLE
fix: metadata type limited to boolean, string or number

### DIFF
--- a/service/openapi.yaml
+++ b/service/openapi.yaml
@@ -178,6 +178,11 @@ components:
               description: Variant of the evaluated flag value
             metadata:
               type: object
+              additionalProperties:
+                oneOf:
+                  - type: boolean
+                  - type: string
+                  - type: number
               description: Arbitrary metadata supporting flag evaluation
         - oneOf:
             - $ref: "#/components/schemas/booleanFlag"


### PR DESCRIPTION
This PR changes the type for flag metadata.
The spec was referring to metadata as `object`, but if we follow the [specification of metadata](https://openfeature.dev/specification/sections/providers/#requirement-2210) it says

> flag metadata MUST be a structure supporting the definition of arbitrary properties, with keys of type string, and values of type boolean | string | number.

In this PR we limit the metadata with values of types `string`, `number` or `boolean`.