### PR TITLE
feat: Add metadata endpoint

### DIFF
--- a/service/openapi.yaml
+++ b/service/openapi.yaml
@@ -34,7 +34,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/configuraitonResponse'
+                $ref: '#/components/schemas/configurationResponse'
         '304':
           description: Flag Management System Metadata is not modified
         '401':
@@ -314,7 +314,7 @@ components:
     errorDetails:
       type: string
       description: An error description for logging or other needs
-    configuraitonResponse:
+    configurationResponse:
       description: OFREP metadata response
       properties:
         name:

--- a/service/openapi.yaml
+++ b/service/openapi.yaml
@@ -12,10 +12,10 @@ security:
   - ApiKeyAuth: [ ]
   - BearerAuth: [ ]
 paths:
-  /ofrep/v1/metadata:
+  /ofrep/v1/configuration:
     get:
-      summary: OFREP metadata
-      description: OFREP metadata to provide information about the remote flag management system, to configure the OpenFeature SDK providers. This endpoint is called during the initialization of the provider.
+      summary: OFREP provider configuration
+      description: OFREP configuration to provide information about the remote flag management system, to configure the OpenFeature SDK providers. This endpoint will be called during the initialization of the provider.
       parameters:
         - in: header
           name: If-None-Match

--- a/service/openapi.yaml
+++ b/service/openapi.yaml
@@ -16,13 +16,27 @@ paths:
     get:
       summary: OFREP metadata
       description: OFREP metadata , it gives information about the remote flag management system, to configure the providers. This endpoint is called during the initialization of the provider.
+      parameters:
+        - in: header
+          name: If-None-Match
+          description: The request will be processed only if ETag doesn't match any of the values listed.
+          schema:
+            type: string
+          required: false
       responses:
         '200':
           description: OFREP metadata response
+          headers:
+            ETag:
+              schema:
+                type: string
+              description: Entity tag used for cache validation
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/metadataResponse'
+        '304':
+          description: Flag Management System Metadata is not modified
         '401':
           description: Unauthorized - You need credentials to access the API
         '403':

--- a/service/openapi.yaml
+++ b/service/openapi.yaml
@@ -344,7 +344,7 @@ components:
           description: set to true if the remote flag management system is supporting polling
         minPollingInterval:
           type: number
-          description: minimum polling interval (in millisecond) supported by the flag management system. The provider should ensure not to  set any polling value under this minimum.
+          description: minimum polling interval (in millisecond) supported by the flag management system. The provider should ensure not to set any polling value under this minimum.
           examples:
             - 60000
       required:

--- a/service/openapi.yaml
+++ b/service/openapi.yaml
@@ -325,7 +325,7 @@ components:
             - go-feature-flag
         capabilities:
           type: object
-          description: List of the features supported by the flag management system.
+          description: Capabilities of the flag management system and how to configure them in the provider.
           properties:
             cacheInvalidation:
               $ref: '#/components/schemas/featureCacheInvalidation'

--- a/service/openapi.yaml
+++ b/service/openapi.yaml
@@ -323,7 +323,7 @@ components:
           examples:
             - flagd
             - go-feature-flag
-        features:
+        capabilities:
           type: object
           description: List of the features supported by the flag management system.
           properties:

--- a/service/openapi.yaml
+++ b/service/openapi.yaml
@@ -342,12 +342,10 @@ components:
         enabled:
           type: boolean
           description: set to true if the remote flag management system is supporting polling
-          default: false
         minPollingInterval:
           type: number
           description: minimum polling interval (in millisecond) supported by the flag management system. The provider should ensure not to set any polling value under this minimum.
           examples:
             - 60000
-          default: 60000
       required:
         - name

--- a/service/openapi.yaml
+++ b/service/openapi.yaml
@@ -342,10 +342,12 @@ components:
         enabled:
           type: boolean
           description: set to true if the remote flag management system is supporting polling
+          default: false
         minPollingInterval:
           type: number
           description: minimum polling interval (in millisecond) supported by the flag management system. The provider should ensure not to set any polling value under this minimum.
           examples:
             - 60000
+          default: 60000
       required:
         - name

--- a/service/openapi.yaml
+++ b/service/openapi.yaml
@@ -15,7 +15,7 @@ paths:
   /ofrep/v1/metadata:
     get:
       summary: OFREP metadata
-      description: OFREP metadata , it gives information about the remote flag management system, to configure the providers. This endpoint is called during the initialization of the provider.
+      description: OFREP metadata to provide information about the remote flag management system, to configure the OpenFeature SDK providers. This endpoint is called during the initialization of the provider.
       parameters:
         - in: header
           name: If-None-Match

--- a/service/openapi.yaml
+++ b/service/openapi.yaml
@@ -12,6 +12,27 @@ security:
   - ApiKeyAuth: [ ]
   - BearerAuth: [ ]
 paths:
+  /ofrep/v1/metadata:
+    get:
+      summary: OFREP metadata
+      description: OFREP metadata , it gives information about the remote flag management system, to configure the providers. This endpoint is called during the initialization of the provider.
+      responses:
+        '200':
+          description: OFREP metadata response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/metadataResponse'
+        '401':
+          description: Unauthorized - You need credentials to access the API
+        '403':
+          description: Forbidden - You are not authorized to access the API
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/generalErrorResponse'
   /ofrep/v1/evaluate/flags/{key}:
     post:
       description: OFREP single flag evaluation request
@@ -279,3 +300,33 @@ components:
     errorDetails:
       type: string
       description: An error description for logging or other needs
+    metadataResponse:
+      description: OFREP metadata response
+      properties:
+        name:
+          type: string
+          description: name of the flag management system
+          examples:
+            - flagd
+            - go-feature-flag
+        features:
+          type: object
+          description: List of the features supported by the flag management system.
+          properties:
+            cacheInvalidation:
+              type: array
+              enum: [POLLING]
+              description: list of the cache invalidation mechanisme supported by the flag management system.
+              examples:
+                - [POLLING]
+        configurations:
+          type: object
+          description: Configuration of the providers specific for the flag management system.
+          properties:
+            minPollingInterval:
+              type: number
+              description: minimum polling interval (in millisecond) supported by the flag management system. The provider should ensure not to set any polling value under this minimum.
+              examples:
+                - 60000
+      required:
+        - name

--- a/service/openapi.yaml
+++ b/service/openapi.yaml
@@ -34,7 +34,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/metadataResponse'
+                $ref: '#/components/schemas/configuraitonResponse'
         '304':
           description: Flag Management System Metadata is not modified
         '401':
@@ -314,7 +314,7 @@ components:
     errorDetails:
       type: string
       description: An error description for logging or other needs
-    metadataResponse:
+    configuraitonResponse:
       description: OFREP metadata response
       properties:
         name:

--- a/service/openapi.yaml
+++ b/service/openapi.yaml
@@ -328,19 +328,24 @@ components:
           description: List of the features supported by the flag management system.
           properties:
             cacheInvalidation:
-              type: array
-              enum: [POLLING]
-              description: list of the cache invalidation mechanisme supported by the flag management system.
-              examples:
-                - [POLLING]
-        configurations:
-          type: object
-          description: Configuration of the providers specific for the flag management system.
-          properties:
-            minPollingInterval:
-              type: number
-              description: minimum polling interval (in millisecond) supported by the flag management system. The provider should ensure not to set any polling value under this minimum.
-              examples:
-                - 60000
+              $ref: '#/components/schemas/featureCacheInvalidation'
+    featureCacheInvalidation:
+      type: object
+      description: Configuration for the cache cacheInvalidation
+      properties:
+        polling:
+          $ref: '#/components/schemas/featureCacheInvalidationPolling'
+    featureCacheInvalidationPolling:
+      type: object
+      description: Configuration of the polling for the featureCacheInvalidation
+      properties:
+        enabled:
+          type: boolean
+          description: set to true if the remote flag management system is supporting polling
+        minPollingInterval:
+          type: number
+          description: minimum polling interval (in millisecond) supported by the flag management system. The provider should ensure not to  set any polling value under this minimum.
+          examples:
+            - 60000
       required:
         - name


### PR DESCRIPTION
## This PR
This PR adds the support of a new endpoint  `/ofrep/v1/configuration` in the OFREP OpenAPI spec.  
This new endpoint is here to be able to expose some information about the flag management system to the generic provider.

This endpoint will be called during the [initialization](https://openfeature.dev/specification/sections/providers/#24-initialization) of the provider and will allow the provider to configure itself based on the configuration received.

This endpoint will return basic information such as the `name` of the flag management system. 
But also what `features` are supported by the remote flag management systems,  and basic remote configuration on how the provider should behave.

This 1st version does not contain a lot of possible configuration, but we will be able to extend it as we continue to evolve the OpenFeature Remote Evaluation Protocol.