### PR TITLE
feat: Add unsupported evaluation types

### DIFF
--- a/service/openapi.yaml
+++ b/service/openapi.yaml
@@ -330,8 +330,8 @@ components:
             cacheInvalidation:
               $ref: '#/components/schemas/featureCacheInvalidation'
             flagEvaluation:
-              $ref: '#/components/schemas/featureEvaluation'
-    featureEvaluation:
+              $ref: '#/components/schemas/flagEvaluation'
+    flagEvaluation:
       type: object
       description: Configurations specific for flag evaluations in OFREP provider implementation
       properties:

--- a/service/openapi.yaml
+++ b/service/openapi.yaml
@@ -336,7 +336,7 @@ components:
       description: Configuration on how to do flag evaluation in the providers.
       properties:
         unsupportedTypes:
-          description: List of unsupported types by the flag management system, it will return an error if we call the type associated function in the OFREP providers.
+          description: A list of unsupported types by the flag management system. Evaluating a flag of a listed type through OFREP provider will result in an error and yield the default value
           type: array
           items:
             type: string

--- a/service/openapi.yaml
+++ b/service/openapi.yaml
@@ -333,7 +333,7 @@ components:
               $ref: '#/components/schemas/featureEvaluation'
     featureEvaluation:
       type: object
-      description: Configurations specific for flag evaluations at OFREP provider implementation
+      description: Configurations specific for flag evaluations in OFREP provider implementation
       properties:
         unsupportedTypes:
           description: A list of unsupported types by the flag management system. Evaluating a flag of a listed type through OFREP provider will result in an error and yield the default value

--- a/service/openapi.yaml
+++ b/service/openapi.yaml
@@ -336,7 +336,7 @@ components:
       description: Configurations specific for flag evaluations in OFREP provider implementation
       properties:
         unsupportedTypes:
-          description: A list of unsupported types by the flag management system. Evaluating a flag of a listed type through OFREP provider will result in an error and yield the default value
+          description: A list of unsupported types by the flag management system. Evaluating a flag of a listed type through OFREP provider will result in an error and yield the default value.
           type: array
           items:
             type: string

--- a/service/openapi.yaml
+++ b/service/openapi.yaml
@@ -333,7 +333,7 @@ components:
               $ref: '#/components/schemas/featureEvaluation'
     featureEvaluation:
       type: object
-      description: Configuration on how to do flag evaluation in the providers.
+      description: Configurations specific for flag evaluations at OFREP provider implementation
       properties:
         unsupportedTypes:
           description: A list of unsupported types by the flag management system. Evaluating a flag of a listed type through OFREP provider will result in an error and yield the default value

--- a/service/openapi.yaml
+++ b/service/openapi.yaml
@@ -329,7 +329,7 @@ components:
           properties:
             cacheInvalidation:
               $ref: '#/components/schemas/featureCacheInvalidation'
-            evaluation:
+            flagEvaluation:
               $ref: '#/components/schemas/featureEvaluation'
     featureEvaluation:
       type: object

--- a/service/openapi.yaml
+++ b/service/openapi.yaml
@@ -329,6 +329,19 @@ components:
           properties:
             cacheInvalidation:
               $ref: '#/components/schemas/featureCacheInvalidation'
+            evaluation:
+              $ref: '#/components/schemas/featureEvaluation'
+    featureEvaluation:
+      type: object
+      description: Configuration for the cache cacheInvalidation
+      properties:
+        unsupportedTypes:
+          type: array
+          items:
+            type: string
+            enum: [int, float, string, boolean, object]
+          examples:
+            - ["object", "int", "float"]
     featureCacheInvalidation:
       type: object
       description: Configuration for the cache cacheInvalidation

--- a/service/openapi.yaml
+++ b/service/openapi.yaml
@@ -333,9 +333,10 @@ components:
               $ref: '#/components/schemas/featureEvaluation'
     featureEvaluation:
       type: object
-      description: Configuration for the cache cacheInvalidation
+      description: Configuration on how to do flag evaluation in the providers.
       properties:
         unsupportedTypes:
+          description: List of unsupported types by the flag management system, it will return an error if we call the type associated function in the OFREP providers.
           type: array
           items:
             type: string


### PR DESCRIPTION
## This PR
In this PR we add a new configuration in the `/ofrep/v1/configuration` endpoint that lets the flag management system specify which types the system is not supporting.

By default, we consider that all flag types are supported, but if a type is specified in `unsupportedTypes` we will return an error every time someone is trying to call the associated evaluation function.

### Example
If the configuration endpoint is returning something like this:
```json
{
  // ...
  "capabilities": {
	"evaluation": {
	  "unsupportedTypes": ["object", "int", "float"]
    }
  }
}
```

When using the provider, and calling the `ObjectValue` we expect to get an error without trying to call the remote flag management system.

This function will always return an error and the default value without doing any HTTP calls.
```go
objectValue, err := client.ObjectValue(context.Background(), "objectFlag", myObject, openfeature.EvaluationContext{})
```
