### PR TITLE
chore: add OpenAPI spec validator based on redocly cli

### DIFF
--- a/.github/workflows/spec-validate.yaml
+++ b/.github/workflows/spec-validate.yaml
@@ -1,0 +1,20 @@
+name: OpenAPI spec validation action
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Run OpenAPI spec validation
+        run: |
+          docker run --rm -v $PWD:/spec redocly/cli lint ./service/openapi.yaml
+          echo "{exit_code}={$?}" >> $GITHUB_STATE

--- a/service/openapi.yaml
+++ b/service/openapi.yaml
@@ -1,4 +1,6 @@
 openapi: 3.1.0
+servers:
+  - url: /
 info:
   version: 0.1.0
   title: OpenFeature Remote Evaluation Protocol (OFREP)
@@ -49,6 +51,7 @@ paths:
                 $ref: '#/components/schemas/generalErrorResponse'
   /ofrep/v1/evaluate/flags/{key}:
     post:
+      summary: OFREP single flag evaluation contract
       description: OFREP single flag evaluation request
       parameters:
         - name: key
@@ -102,6 +105,7 @@ paths:
                 $ref: '#/components/schemas/generalErrorResponse'
   /ofrep/v1/evaluate/flags:
     post:
+      summary: OFREP bulk flag evaluation contract
       description: OFREP bulk evaluation request
       parameters:
         - in: header


### PR DESCRIPTION
## This PR

Adds a GitHub action to validate OpenAPI spec using redocly cli. Note that I have fixed currently reported issues which doesn't change anything special in the spec. 

Replacement for https://github.com/open-feature/protocol/pull/13 
