### PR TITLE
feat: Specify caching for OFREP in server providers

### DIFF
--- a/service/openapi.yaml
+++ b/service/openapi.yaml
@@ -48,7 +48,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/evaluationSuccess'
+                $ref: '#/components/schemas/serverEvaluationSuccess'
         '400':
           description: Bad evaluation request
           content:
@@ -221,6 +221,13 @@ components:
       properties:
         context:
           $ref: '#/components/schemas/context'
+    serverEvaluationSuccess:
+      allOf:
+        - $ref: "#/components/schemas/evaluationSuccess"
+        - properties:
+            cacheable:
+              type: boolean
+              description: Let the provider know that this flag evaluation can be cached
     evaluationSuccess:
       description: Flag evaluation success response.
       allOf:
@@ -354,6 +361,8 @@ components:
               $ref: '#/components/schemas/featureCacheInvalidation'
             flagEvaluation:
               $ref: '#/components/schemas/flagEvaluation'
+            caching:
+              $ref: '#/components/schemas/featureCaching'
     flagEvaluation:
       type: object
       description: Configurations specific for flag evaluations in OFREP provider implementation
@@ -391,3 +400,15 @@ components:
             - 60000
       required:
         - name
+    featureCaching:
+      type: object
+      description: Configuration of the caching mechanism in the provider (used by server providers)
+      properties:
+        enabled:
+          type: boolean
+          description: set to true if you want the provider to cache the evaluation results
+        ttl:
+          type: number
+          examples:
+            - 1000
+          description: number (in millisecond) to wait before invalidating the cache. If we have cacheInvalidation enabled, the cache can also be evicted if a configuration change happen.


### PR DESCRIPTION
## This PR

### Why this feature?
With the current implementation of OFREP on the server side the provider has to do a remote call to an API for each evaluation which can add latency to the application.
This caching mechanism helps to reduce the overhead of calling the API each time.

The `cacheable` field is here for the flag management system to notify the provider that it is ok to cache this flag evaluation. We don't want to cache all evaluations because some of them contain time-based changes and in those cases, we accept calling multiple times the API because the evaluation result can change and the cache will not be reliable.
By setting the `cacheable` field we let the decision to the flag management system.



### Sequence diagram
This sequence diagram explains how it can work from a provider's perspective.
```mermaid
sequenceDiagram
    participant c as Server Application
    participant p as OFREP Provider
    participant f as Flag Management<br/>System
    c ->> p: client.getBooleanValue('v2_enabled', false);
    p -->> p: retrieve combination of flag + context<br/>from the cache
    alt not available in the cache
        p ->> f: call /ofrep/v1/evaluate/flags/v2_enabled<br/>with evaluation context
        f -->> p: 200 + evaluation result
        p -->> p: If cacheable = true, store in a cache<br/>Key: combination of flag + context<br/>Value: evaluation result<br/>(Data will be evicted from the cache after the TTL<br/>OR<br/>If we get notify from a configuration change)
        p -->> c: evaluation result
    else available in the cache
        p -->> c: evaluation result (with CACHED reason)
    end
```

