### PR TITLE
feat: reversed lack of support to support capabilities

### DIFF
--- a/service/openapi.yaml
+++ b/service/openapi.yaml
@@ -335,18 +335,21 @@ components:
               $ref: '#/components/schemas/featureCacheInvalidation'
             flagEvaluation:
               $ref: '#/components/schemas/flagEvaluation'
+      required:
+        - name
     flagEvaluation:
       type: object
       description: Configurations specific for flag evaluations in OFREP provider implementation
       properties:
-        unsupportedTypes:
-          description: A list of unsupported types by the flag management system. Evaluating a flag of a listed type through OFREP provider will result in an error and yield the default value.
+        supportedTypes:
+          description: |
+            A list of supported types by the flag management system.
+            Evaluating a flag of an unlisted type through OFREP provider will result in an error and yield the default value.
           type: array
           items:
             type: string
-            enum: [int, float, string, boolean, object]
           examples:
-            - ["object", "int", "float"]
+            - [ boolean, integer, decimal, string, object ]
     featureCacheInvalidation:
       type: object
       description: Configuration for the cache cacheInvalidation
@@ -365,5 +368,3 @@ components:
           description: minimum polling interval (in millisecond) supported by the flag management system. The provider should ensure not to set any polling value under this minimum.
           examples:
             - 60000
-      required:
-        - name


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

1. Reverses the `unsupportedTypes` to `supportedTypes`
2. Removes enumeration of supported types
3. Restores the required `name` in the `configurationResponse`

### Related Issues

N/A

### Notes
<!-- any additional notes for this PR -->

1. It is not a capability to not support something.
   Instead the response should express its ability to support such types.
   I reversed the naming of this capability because as this specification updates, this would force providers either to immediately show a new type to be unsupported or to immediately support a new type.
2. I removed the limitations of supported types. Adding values to an enum in a response is a breaking change. The goal is to allow a new type in the OpenFeature specification while limiting breaking changes on this OpenAPI specification.
3. I think this `required` clause was wrongly moved. I'm merely bringing it back up.
   I would nevertheless question the requirement of this property as it does not add any significant value to a client.

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

N/A

### How to test
<!-- if applicable, add testing instructions under this section -->

N/A
