### PR TITLE
feat: Remove name from configuration response

### DIFF
--- a/service/openapi.yaml
+++ b/service/openapi.yaml
@@ -321,12 +321,6 @@ components:
     configurationResponse:
       description: OFREP metadata response
       properties:
-        name:
-          type: string
-          description: name of the flag management system
-          examples:
-            - flagd
-            - go-feature-flag
         capabilities:
           type: object
           description: Capabilities of the flag management system and how to configure them in the provider.
@@ -365,5 +359,3 @@ components:
           description: minimum polling interval (in millisecond) supported by the flag management system. The provider should ensure not to set any polling value under this minimum.
           examples:
             - 60000
-      required:
-        - name


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- Removes name from the `GET /ofrep/v1/configuration` response

### Notes
<!-- any additional notes for this PR -->

This property provides no added value to the API client.

While I understand why a vendor want to promote his product by name, this is the role of the [`Server` HTTP header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Server).