### PR TITLE
feat!: change minPollingInterval field name to mention millisecond

### DIFF
--- a/service/openapi.yaml
+++ b/service/openapi.yaml
@@ -360,9 +360,11 @@ components:
         enabled:
           type: boolean
           description: set to true if the remote flag management system is supporting polling
-        minPollingInterval:
+        minPollingIntervalInMs:
           type: number
-          description: minimum polling interval (in millisecond) supported by the flag management system. The provider should ensure not to set any polling value under this minimum.
+          description: |
+            Minimum polling interval (in millisecond) supported by the flag management system.  
+            The provider should ensure not to set any polling value under this minimum.
           examples:
             - 60000
       required:

--- a/service/openapi.yaml
+++ b/service/openapi.yaml
@@ -360,7 +360,7 @@ components:
         enabled:
           type: boolean
           description: set to true if the remote flag management system is supporting polling
-        minPollingIntervalInMs:
+        minPollingIntervalMs:
           type: number
           description: |
             Minimum polling interval (in millisecond) supported by the flag management system.  


### PR DESCRIPTION
## This PR
This PR renames in the `configuration` endpoint the `minPollingInterval` to `minPollingIntervalInMs` to be explicit to API users that the value expected should be in milliseconds.

⚠️ Breaking change: since we are still in WIP mode for OFREP we accept this breaking change.
