### PR TITLE
feat: make flags property mandatory for bulk evaluation success response

### DIFF
--- a/service/openapi.yaml
+++ b/service/openapi.yaml
@@ -198,6 +198,8 @@ components:
     bulkEvaluationSuccess:
       description: Success response for the bulk evaluation request
       type: object
+      required:
+        - flags
       properties:
         flags:
           type: array


### PR DESCRIPTION
**Background**

`bulkEvaluationSuccess` right now only defines `flags` property. This is the main property the response is expected to contain. 

**Proposal**

With this PR, I have made the `flags` property mandatory in the bulk evaluation response. This confirms to the current JavaScript implementation [1] where `flags` is required to make the response a valid one.

[1] - https://github.com/open-feature/js-sdk-contrib/blob/ofrep-core-v0.1.5/libs/shared/ofrep-core/src/lib/model/bulk-evaluation.ts#L32-L38