### PR TITLE
feat: add flag set metadata for bulk response and failures

### DIFF
--- a/service/openapi.yaml
+++ b/service/openapi.yaml
@@ -201,6 +201,8 @@ components:
       required:
         - flags
       properties:
+        metadata:
+          $ref: "#/components/schemas/metadata"
         flags:
           type: array
           items:
@@ -244,13 +246,7 @@ components:
               type: string
               description: Variant of the evaluated flag value
             metadata:
-              type: object
-              additionalProperties:
-                oneOf:
-                  - type: boolean
-                  - type: string
-                  - type: number
-              description: Arbitrary metadata supporting flag evaluation
+              $ref: "#/components/schemas/metadata"
         - oneOf:
             - $ref: "#/components/schemas/booleanFlag"
             - $ref: "#/components/schemas/stringFlag"
@@ -268,6 +264,8 @@ components:
           description: OpenFeature compatible error code. See https://openfeature.dev/specification/types#error-code
         errorDetails:
           $ref: '#/components/schemas/errorDetails'
+        metadata:
+          $ref: "#/components/schemas/metadata"
       required:
         - key
         - errorCode
@@ -281,6 +279,8 @@ components:
           enum: [ FLAG_NOT_FOUND ]
         errorDetails:
           $ref: '#/components/schemas/errorDetails'
+        metadata:
+          $ref: "#/components/schemas/metadata"
       required:
         - key
         - errorCode
@@ -421,3 +421,15 @@ components:
           examples:
             - 1000
           description: number (in millisecond) to wait before invalidating the cache. If we have cacheInvalidation enabled, the cache can also be evicted if a configuration change happen.
+    metadata: 
+      type: object
+      additionalProperties:
+        oneOf:
+          - type: boolean
+          - type: string
+          - type: number
+      examples:
+        - flagSetId: holidays-sales
+          version: v12
+          team: ecommerce
+      description: Arbitrary metadata for the flag or flag set, useful for telemetry and documentary purposes.

--- a/service/openapi.yaml
+++ b/service/openapi.yaml
@@ -201,14 +201,18 @@ components:
       required:
         - flags
       properties:
-        metadata:
-          $ref: "#/components/schemas/metadata"
         flags:
           type: array
           items:
             oneOf:
               - $ref: "#/components/schemas/evaluationSuccess"
               - $ref: '#/components/schemas/evaluationFailure'
+        metadata:
+          $ref: "#/components/schemas/metadata"
+          description: Arbitrary metadata for the flag set, useful for telemetry and documentary purposes.
+          examples:
+            - flagSetId: holidaySales
+              version: v12
     bulkEvaluationFailure:
       description: Bulk evaluation failure response
       properties:
@@ -246,7 +250,10 @@ components:
               type: string
               description: Variant of the evaluated flag value
             metadata:
-              $ref: "#/components/schemas/metadata"
+              allOf:
+                - $ref: "#/components/schemas/metadata"
+                - $ref: "#/components/schemas/flagMetadataDescription"
+                - $ref: "#/components/schemas/flagMetadataExamples"
         - oneOf:
             - $ref: "#/components/schemas/booleanFlag"
             - $ref: "#/components/schemas/stringFlag"
@@ -265,7 +272,10 @@ components:
         errorDetails:
           $ref: '#/components/schemas/errorDetails'
         metadata:
-          $ref: "#/components/schemas/metadata"
+          allOf:
+            - $ref: "#/components/schemas/metadata"
+            - $ref: "#/components/schemas/flagMetadataDescription"
+            - $ref: "#/components/schemas/flagMetadataExamples"
       required:
         - key
         - errorCode
@@ -280,7 +290,10 @@ components:
         errorDetails:
           $ref: '#/components/schemas/errorDetails'
         metadata:
-          $ref: "#/components/schemas/metadata"
+          allOf:
+            - $ref: "#/components/schemas/metadata"
+            - $ref: "#/components/schemas/flagMetadataDescription"
+            - $ref: "#/components/schemas/flagMetadataExamples"
       required:
         - key
         - errorCode
@@ -428,8 +441,10 @@ components:
           - type: boolean
           - type: string
           - type: number
+    flagMetadataExamples:
       examples:
-        - flagSetId: holidays-sales
-          version: v12
-          team: ecommerce
-      description: Arbitrary metadata for the flag or flag set, useful for telemetry and documentary purposes.
+        - team: ecommerce
+          businessPurpose: experiment 
+    flagMetadataDescription:
+      description: Arbitrary metadata for the flag, useful for telemetry and documentary purposes.
+


### PR DESCRIPTION
This PR adds the existing metadata flag prop to the bulk evaluation and to failures.

These cases are particularly important for telemetry (see our recent addition of appendix D). Even in error cases, flag metadata (such as the version, flag set id, etc) can be very useful in debugging and metrics. These additions facilitate these use cases, and are non-breaking and backwards compatible.

The existing `metadata` struct has been moved to the components section for reuse.

![image](https://github.com/user-attachments/assets/8bb4dc58-afe6-4e0a-8b26-e27d4d072717)

![image](https://github.com/user-attachments/assets/d3edcd6a-1aea-458e-bd8f-0060f0f27c9b)
