### PR TITLE
feat!: remove cacheable property

### DIFF
--- a/service/openapi.yaml
+++ b/service/openapi.yaml
@@ -192,10 +192,6 @@ components:
     serverEvaluationSuccess:
       allOf:
         - $ref: "#/components/schemas/evaluationSuccess"
-        - properties:
-            cacheable:
-              type: boolean
-              description: Let the provider know that this flag evaluation can be cached
     evaluationSuccess:
       description: Flag evaluation success response.
       allOf:


### PR DESCRIPTION
## This PR
Remove `cacheable` property because there is no plan to support cache in the providers before `1.0`.