### PR TITLE
docs: mark ADRs 0008, 0009, and 0010 as accepted

### DIFF
--- a/service/adrs/0008-sse-for-bulk-evaluation-changes.md
+++ b/service/adrs/0008-sse-for-bulk-evaluation-changes.md
@@ -4,7 +4,7 @@ Date: 2026-02-20
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 

--- a/service/adrs/0009-local-storage-for-static-context-providers.md
+++ b/service/adrs/0009-local-storage-for-static-context-providers.md
@@ -4,7 +4,7 @@ Date: 2026-03-06
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 

--- a/service/adrs/0010-disable-default-polling-for-static-context-providers.md
+++ b/service/adrs/0010-disable-default-polling-for-static-context-providers.md
@@ -4,7 +4,7 @@ Date: 2026-03-19
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 


### PR DESCRIPTION
## Summary

- Marks ADR 0008 (SSE for bulk evaluation changes) as Accepted (#63, #67)
- Marks ADR 0009 (local storage for static-context providers) as Accepted (#75)
- Marks ADR 0010 (disable default polling for static-context providers) as Accepted (#69)

The corresponding PRs for all three ADRs have been merged.